### PR TITLE
fix different stroke and fill colors

### DIFF
--- a/ui/svg-helpers.tsx
+++ b/ui/svg-helpers.tsx
@@ -12,7 +12,7 @@ export function getTrianglesWithColorAndFill(paths: string[]) {
     const color = getColor(Math.random() < 0.5 ? "primary" : "secondary");
     const hasFill = Math.random() < 0.5;
     return (
-      <path key={index} d={path} stroke={color} fill={hasFill ? color : ""} />
+      <path key={index} d={path} stroke={color} fill={hasFill ? color : "var(--background)"} />
     );
   });
 }


### PR DESCRIPTION
the bug: in some rare occasians some of the triangles had different fill and stroke colors
![CleanShot 2023-11-30 at 10 29 57](https://github.com/JSConfBp/2024.jsconfbp.com/assets/7690112/62796ab6-c1e1-4f34-a1c9-060fe2625865)

I honestly don't know why this fix works, but seemingly it does probably invalidates cache or something

