### PR TITLE
fix nametags on about us pictures

### DIFF
--- a/pages/about-us.tsx
+++ b/pages/about-us.tsx
@@ -7,7 +7,7 @@ import Youtube from '../ui/youtube'
 
 const team = [
   {
-    name: 'Szabolcs Szabolcsi-Tóth',
+    name: 'Szabolcs Szabolcsi&#8209;Tóth',
     image: 'https://nec.is/nec.png',
     twitter: '_nec',
   },
@@ -128,7 +128,7 @@ function About() {
               <span>
                 <img alt={member.name} src={member.image} />
               </span>
-              <span className={styles.name}>{member.name}</span>
+              <span className={styles.name} dangerouslySetInnerHTML={{ __html: member.name }}></span>
             </a>
           </li>
           )

--- a/pages/about.module.scss
+++ b/pages/about.module.scss
@@ -12,6 +12,8 @@
 
     img {
       width: 100%;
+      height: 100%;
+      object-fit: cover;
     }
 
     .name {
@@ -19,13 +21,10 @@
       left: 0;
       bottom: 0;
       padding: 0.2rem 0.5rem;
-      display: inline-block;
-      border-radius: 10px;
-      margin: 0 0 -0.5rem -2rem;
       background-color: var(--secondary);
       color: var(--background);
       font-weight: bold;
-      font-size: 1.3rem;
+      font-size: 1rem;
     }
   }
 }


### PR DESCRIPTION
note to self: it's not possible in css to wrap on space
but not on hyphen

&#8209; - this is the non-breaking hyphen
sadly it needs dangerouslySetInnerHTML but 🤷‍♂️